### PR TITLE
Fix the function name in the README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ from typing_derive.impl import typeddict_from_func
 
 def f(x: int, y: str) -> None: ...
 
-TD = typeddict_from('TD', f)
+TD = typeddict_from_func('TD', f)
 
 x: TD = {
     'x': 1,


### PR DESCRIPTION
You pointed it out on Discord, and I had a spare second. Figured it wouldn't hurt.